### PR TITLE
Count vectors from different runs can be of different lengths

### DIFF
--- a/src/ocverallsBisect.ml
+++ b/src/ocverallsBisect.ml
@@ -70,7 +70,8 @@ let coverage_data
   (* Combine all files runtime data:
    * point coverage is the sum of counters of
    * each file associated to it. *)
-  let combine a1 a2 = Array.mapi (fun i v -> v + a2.(i)) a1 in
+  let combine a1 a2 =
+    Array.mapi (fun i v -> v + (if i < Array.length a2 then a2.(i) else 0)) a1 in
   let data = List.map B.read_runtime_data files |> List.flatten in
   (* For each file in data,
    * Combine information in data abouth this file. *)


### PR DESCRIPTION
When combining the output from several seperate invocations (e.g.
when using a glob like *.out), sometimes bisect will include
vectors of different lengths for the same file. This patch avoids
the exception by assuming missing elements are 0.

Fixes #4

Signed-off-by: David Scott dave.scott@citrix.com
