### PR TITLE
Depend on bisect or bisect_ppx.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,20 @@
 all: build
 
+# Choose where we get the runtime based on what's installed
+ifeq ($(shell ocamlfind query bisect >/dev/null 2>&1 && echo y),y)
+BISECT=bisect
+else ifeq ($(shell ocamlfind query bisect_ppx >/dev/null 2>&1 && echo y),y)
+BISECT=bisect_ppx
+endif
+
 build:
+ifndef BISECT
+	$(error No bisect runtime)
+else
 	ocamlbuild -use-ocamlfind \
-	-I src -pkgs ezjsonm,bisect,unix \
-	ocveralls.native
+		-I src -pkgs ezjsonm,$(BISECT),unix \
+		ocveralls.native
+endif
 
 install: build
 ifndef bindir

--- a/opam
+++ b/opam
@@ -16,5 +16,5 @@ remove:  [ "rm" "-f" "%{bin}%/ocveralls" ]
 depends: [
   "ocamlfind" { build }
   "ezjsonm" { build & >="0.4.0" }
-  "bisect" { build }
+  ("bisect" | "bisect_ppx" { build })
 ]


### PR DESCRIPTION
This would prevent users of `ocveralls` and `bisect_ppx` from having to install `bisect` too.
