### PR TITLE
Depend on package str.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ifndef BISECT
 	$(error No bisect runtime)
 else
 	ocamlbuild -use-ocamlfind \
-		-I src -pkgs ezjsonm,$(BISECT),unix \
+		-I src -pkgs ezjsonm,$(BISECT),unix,str \
 		ocveralls.native
 endif
 


### PR DESCRIPTION
See the commit message. Existing ocveralls releases are only going to be compatible with Bisect_ppx <= 0.2.6. It may be worth updating their `opam` files.
