### PR TITLE
Point to Bisect_ppx.

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -3,7 +3,8 @@
 ![travis status](https://travis-ci.org/sagotch/ocveralls.svg?branch=test)
 
 Produce JSON for [coveralls.io](https://coveralls.io/) from
-[bisect](http://bisect.x9c.fr/index.html) coverage data.
+[Bisect_ppx](https://github.com/rleonid/bisect_ppx) coverage data. Also works with
+the original [Bisect](http://bisect.x9c.fr/index.html).
 
 ## Usage
 


### PR DESCRIPTION
This changes the link in the README to point to Bisect_ppx.

Some reasons:
- The OCaml community is gradually moving to ppx. The original Bisect claims to support ppx, but it looks like its `opam` file doesn't try to compile the ppx extension, except on 4.00.1. I am not sure if Bisect's ppx rewriter is compatible with 4.02 (@rleonid?).
- Bisect_ppx is maintained: @rleonid is the main maintainer, and I am available for help. I don't think Bisect is currently maintained. We have also improved the self-testing, including testing in combination with ocveralls.
- Bisect_ppx has much more thorough instrumentation, e.g. see before and after in https://github.com/rleonid/bisect_ppx/pull/56.
- The HTML reports are more legible and nicer. See http://rleonid.github.io/bisect_ppx/coverage/file0019.html, compared with https://github.com/rleonid/bisect_ppx/blob/8234b735e82f9a1dfdbb63579b3ed55663670a56/src/demo/img/Screenshot2.png.
- Bisect_ppx is more sensitive to other ppx rewriters, e.g. see https://github.com/rleonid/bisect_ppx/commit/36e12333f20bba2218603e9524abf4465e6ee0d5.
- Bisect_ppx uses the fast runtime by default, which simplifies usage (no need to pass options with `ppxopt` to get good testing performance).
